### PR TITLE
Add Solidity coverage report

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ build
 artifacts
 cache
 npm
+coverage/
+coverage.json

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -1,5 +1,6 @@
 require("@nomiclabs/hardhat-waffle");
 require("@openzeppelin/hardhat-upgrades");
+require("solidity-coverage");
 
 /** @type import('hardhat/config').HardhatUserConfig */
 module.exports = {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "@nomicfoundation/edr-linux-x64-gnu": "^0.3.8",
     "@nomiclabs/hardhat-ethers": "^2.2.3",
     "@nomiclabs/hardhat-waffle": "^2.0.6",
-    "@openzeppelin/hardhat-upgrades": "^1.0.0"
+    "@openzeppelin/hardhat-upgrades": "^1.0.0",
+    "solidity-coverage": "^0.8.14"
   },
   "author": "",
   "license": "ISC",


### PR DESCRIPTION
This PR adds `solidity-coverage` package and enables it. 

Usage:

```sh
npx hardhat coverage
```

Check the `./coverage/index.html` file after the report is generated.